### PR TITLE
Replace deprecating set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: version-retriever
-      uses: ./../action.yml
+      uses: ./
     - name: echo retrieved version
       run: echo retrieved version => ${{ steps.version-retriever.outputs.version }}
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: version-retriever
-      uses: CarterChen247/version-retriever
+      uses: CarterChen247/version-retriever@v1
     - name: echo retrieved version
       run: echo retrieved version => ${{ steps.version-retriever.outputs.version }}
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: version-retriever
-      uses: ./
+      uses: CarterChen247/version-retriever
     - name: echo retrieved version
       run: echo retrieved version => ${{ steps.version-retriever.outputs.version }}
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - id: version-retriever
-      uses: CarterChen247/version-retriever@v1
+      uses: Bikermouse/version-retriever@v1
     - name: echo retrieved version
       run: echo retrieved version => ${{ steps.version-retriever.outputs.version }}
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - id: version-retriever
-      uses: ./action.yml
+      uses: ./../action.yml
     - name: echo retrieved version
       run: echo retrieved version => ${{ steps.version-retriever.outputs.version }}
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     name: retrieve branch version
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - id: version-retriever
       uses: ./action.yml
     - name: echo retrieved version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - id: version-retriever
-      uses: Bikermouse/version-retriever@v1
+      uses: ./action.yml
     - name: echo retrieved version
       run: echo retrieved version => ${{ steps.version-retriever.outputs.version }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
         echo "branch_name  => $branch_name"
         echo "version_name => $version_name"
         if [[ $version_name =~ [0-9]+(\\.[0-9]+)* ]]; then
-          echo "::set-output name=result::$(echo $version_name)"
+          echo "result=$(echo $version_name)" >> $GITHUB_OUTPUT
         else
           echo "invalid version format"
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -12,16 +12,15 @@ runs:
   steps: 
     - id: version-retriever
       run: |
-        ref_name=${GITHUB_REF}
-        branch_name=${GITHUB_REF#refs/heads/}
-        version_name=${GITHUB_REF##*/}
+        ref_name=${GITHUB_REF_NAME}
+        ref_type=%{GITHUB_REF_TYPE}
         echo "ref_name     => $ref_name"
-        echo "branch_name  => $branch_name"
-        echo "version_name => $version_name"
-        if [[ $version_name =~ [0-9]+(\\.[0-9]+)* ]]; then
-          echo "result=$(echo $version_name)" >> $GITHUB_OUTPUT
+        echo "ref_type     => $ref_type"
+        if [[ $ref_name =~ [0-9]+(\\.[0-9]+)* ]]; 
+        then
+          echo "result=$(echo $ref_name)" >> $GITHUB_OUTPUT
         else
-          echo "invalid version format"
+          echo "$ref_type $ref_name has invalid format"
           exit 1
         fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
     - id: version-retriever
       run: |
         ref_name=${GITHUB_REF_NAME}
-        ref_type=%{GITHUB_REF_TYPE}
+        ref_type=${GITHUB_REF_TYPE}
         echo "ref_name     => $ref_name"
         echo "ref_type     => $ref_type"
         if [[ $ref_name =~ [0-9]+(\\.[0-9]+)* ]]; 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Version Retriever'
-description: 'retrieve version from branch name'
+description: 'retrieve version from branch/tag name'
 branding:
   color: white
   icon: git-branch


### PR DESCRIPTION
First, I love your action. Thanks for publishing this to the marketplace!

I noticed warnings everytime I used your action, and after some research I found out that the set-output command is being reprecated. 

_"Starting 1st June 2023 workflows using save-state or set-output commands via stdout will fail with an error."_ - [Github Blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

So I changed the script accordingly. The script action now also supports Tags.

P.S. this is my first contribution to an open source project, so please be nice :)

P.P.S. I learned a lot about actions and workflows thanks to this project, so thanks again!